### PR TITLE
Fix: find test declarations with method calls

### DIFF
--- a/jest-test-mode.el
+++ b/jest-test-mode.el
@@ -206,7 +206,7 @@ mode"
   (jest-test-with-debug-flags
     (jest-test-run-at-point)))
 
-(defvar jest-test-declaration-regex "^[ \\t]*\\(it\\|test\\|describe\\)(\\(.*\\),"
+(defvar jest-test-declaration-regex "^[ \\t]*\\(it\\|test\\|describe\\)\\(\\.\\(.*\\)\\)?(\\(.*\\),"
   "Regex for finding a test declaration in jest.
 
 Match Group 1 contains the function name: it, test, describe


### PR DESCRIPTION
Adds support to find tests declared as `test.concurrent()`.